### PR TITLE
log the count of deleted cache entries

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31445,7 +31445,11 @@ async function deleteCache(_a) {
         (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Cache not found: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`);
     }
     else {
-        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Successfully deleted cache${cacheVersion ? " version" : ""}: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`);
+        const data = await response.json();
+        (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Successfully deleted ${prefix ? "caches with prefix" : "cache"}${cacheVersion ? " version" : ""}: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`);
+        if (data.deleted !== undefined) {
+            (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Deleted ${data.deleted} cache entries`);
+        }
     }
 }
 async function run() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,11 +51,15 @@ export async function deleteCache({
       `Cache not found: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`
     );
   } else {
+    const data = await response.json();
     info(
-      `Successfully deleted cache${cacheVersion ? " version" : ""}: ${cacheKey}${
-        cacheVersion ? `@${cacheVersion}` : ""
-      }`
+      `Successfully deleted ${prefix ? "caches with prefix" : "cache"}${
+        cacheVersion ? " version" : ""
+      }: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`
     );
+    if (data.deleted !== undefined) {
+      info(`Deleted ${data.deleted} cache entries`);
+    }
   }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `deleteCache` now logs the count of deleted cache entries and handles empty cache key errors, with updated tests.
> 
>   - **Behavior**:
>     - `deleteCache` in `main.ts` now logs the number of deleted cache entries if the `deleted` field is present in the response.
>     - Handles empty cache key with prefix as false by throwing an error.
>   - **Tests**:
>     - Updated `main.test.ts` to mock `json` response with `deleted` field and verify logging of deleted entries count.
>     - Added test case for empty cache key with prefix as false to ensure error is thrown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fcache-delete&utm_source=github&utm_medium=referral)<sup> for 2c1ece4fa1cf841cc07a8da79d939f06333c562d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->