### PR TITLE
add check against specifying version when key is empty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31427,6 +31427,9 @@ async function deleteCache(_a) {
     if (!cacheKey && !prefix) {
         throw new Error("Cache key cannot be empty unless prefix is true");
     }
+    if (cacheVersion && !cacheKey) {
+        throw new Error("Cannot specify version when using empty key");
+    }
     const resource = cacheVersion ? `${cacheKey}/${cacheVersion}` : cacheKey;
     const url = `${baseUrl}/caches/${resource}`;
     const response = await node_fetch__WEBPACK_IMPORTED_MODULE_1___default()(prefix ? `${url}?prefix` : url, {

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -185,4 +185,15 @@ describe("deleteCache", () => {
       })
     ).rejects.toThrow("Failed to delete cache: 500 Internal Server Error");
   });
+
+  it("should fail if version is specified with empty key", async () => {
+    await expect(
+      deleteCache({
+        cacheKey: "",
+        cacheVersion: "v1.0",
+        prefix: true,
+        ...defaultParams,
+      })
+    ).rejects.toThrow("Cannot specify version when using empty key");
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,9 @@ export async function deleteCache({
   if (!cacheKey && !prefix) {
     throw new Error("Cache key cannot be empty unless prefix is true");
   }
+  if (cacheVersion && !cacheKey) {
+    throw new Error("Cannot specify version when using empty key");
+  }
 
   const resource = cacheVersion ? `${cacheKey}/${cacheVersion}` : cacheKey;
   const url = `${baseUrl}/caches/${resource}`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add validation in `deleteCache` to prevent specifying `cacheVersion` with an empty `cacheKey`, and update tests accordingly.
> 
>   - **Validation**:
>     - Add check in `deleteCache` in `main.ts` to throw error if `cacheVersion` is specified with an empty `cacheKey`.
>   - **Tests**:
>     - Add test case in `main.test.ts` to verify error is thrown when `cacheVersion` is specified with an empty `cacheKey`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fcache-delete&utm_source=github&utm_medium=referral)<sup> for fdcec4219c9eed3baefb23d441d9623b2f7b489e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->