### PR TITLE
disallow setting version when prefix is set

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31430,6 +31430,9 @@ async function deleteCache(_a) {
     if (cacheVersion && !cacheKey) {
         throw new Error("Cannot specify version when using empty key");
     }
+    if (prefix && cacheVersion) {
+        throw new Error("Cannot specify version when using prefix");
+    }
     const resource = cacheVersion ? `${cacheKey}/${cacheVersion}` : cacheKey;
     const url = `${baseUrl}/caches/${resource}`;
     const response = await node_fetch__WEBPACK_IMPORTED_MODULE_1___default()(prefix ? `${url}?prefix` : url, {

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -154,6 +154,17 @@ describe("deleteCache", () => {
     ).rejects.toThrow("Cache key cannot be empty unless prefix is true");
   });
 
+  it("should fail if version is specified with prefix", async () => {
+    await expect(
+      deleteCache({
+        cacheKey: "npm-cache",
+        cacheVersion: "v1.0",
+        prefix: true,
+        ...defaultParams,
+      })
+    ).rejects.toThrow("Cannot specify version when using prefix");
+  });
+
   it("should handle 404 response", async () => {
     mockedFetch.mockResolvedValue({
       ok: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,9 @@ export async function deleteCache({
   if (cacheVersion && !cacheKey) {
     throw new Error("Cannot specify version when using empty key");
   }
+  if (prefix && cacheVersion) {
+    throw new Error("Cannot specify version when using prefix");
+  }
 
   const resource = cacheVersion ? `${cacheKey}/${cacheVersion}` : cacheKey;
   const url = `${baseUrl}/caches/${resource}`;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add validation in `deleteCache` to disallow specifying `cacheVersion` with `prefix` and update tests.
> 
>   - **Behavior**:
>     - In `main.ts`, `deleteCache` now throws an error if `cacheVersion` is specified with `prefix`.
>     - Updated error message: "Cannot specify version when using prefix".
>   - **Tests**:
>     - Added test case in `main.test.ts` to verify error is thrown when `cacheVersion` is used with `prefix`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fcache-delete&utm_source=github&utm_medium=referral)<sup> for 4132086495deb503b7fbb528dcb402efa69d1ce5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->