### PR TITLE
feat: migrate cache deletion to Twirp backend

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31435,11 +31435,11 @@ async function fetchWithRetry(url, options, maxRetries = 3) {
     throw new Error("Retry loop completed without return or throw");
 }
 async function deleteCache(_a) {
-    var _b, _c, _d;
-    var { cacheKey, cacheVersion, prefix = false, baseUrl = process.env.BLACKSMITH_CACHE_URL ||
-        (((_b = process.env.PETNAME) === null || _b === void 0 ? void 0 : _b.includes("staging"))
-            ? "https://stagingapi.blacksmith.sh/cache"
-            : "https://api.blacksmith.sh/cache"), repoName = (_c = process.env["GITHUB_REPO_NAME"]) !== null && _c !== void 0 ? _c : "", cacheToken = process.env["BLACKSMITH_CACHE_TOKEN"], region = (_d = process.env["BLACKSMITH_REGION"]) !== null && _d !== void 0 ? _d : "eu-central", } = _a;
+    var _b;
+    var { cacheKey, cacheVersion, prefix = false, baseUrl = (_b = process.env.ACTIONS_RESULTS_URL) !== null && _b !== void 0 ? _b : "", cacheToken = process.env["BLACKSMITH_CACHE_TOKEN"], } = _a;
+    if (!baseUrl) {
+        throw new Error("ACTIONS_RESULTS_URL not set");
+    }
     if (!cacheKey && !prefix) {
         throw new Error("Cache key cannot be empty unless prefix is true");
     }
@@ -31449,16 +31449,24 @@ async function deleteCache(_a) {
     if (prefix && cacheVersion) {
         throw new Error("Cannot specify version when using prefix");
     }
-    const resource = cacheVersion ? `${cacheKey}/${cacheVersion}` : cacheKey;
-    const url = `${baseUrl}/caches/${resource}`;
-    const response = await fetchWithRetry(prefix ? `${url}?prefix` : url, {
-        method: "DELETE",
+    // The baseURL always has a trailing slash, but we still add it in case it is missing.
+    if (!baseUrl.endsWith("/")) {
+        baseUrl = `${baseUrl}/`;
+    }
+    const url = `${baseUrl}twirp/github.actions.results.api.v1.CacheService/DeleteCacheEntry`;
+    const response = await fetchWithRetry(url, {
+        // Twirp endpoints all use POST.
+        method: "POST",
         headers: {
+            "Content-Type": "application/json",
             Accept: "application/json; version=6.0-preview.1",
-            "X-GitHub-Repo-Name": repoName,
             Authorization: `Bearer ${cacheToken}`,
-            "X-Cache-Region": region,
         },
+        body: JSON.stringify({
+            key: cacheKey,
+            version: cacheVersion,
+            prefix,
+        }),
     });
     if (!response.ok && response.status !== 404) {
         throw new Error(`Failed to delete cache: ${response.status} ${response.statusText}`);
@@ -31469,8 +31477,8 @@ async function deleteCache(_a) {
     else {
         const data = await response.json();
         (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Successfully deleted ${prefix ? "caches with prefix" : "cache"}${cacheVersion ? " version" : ""}: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`);
-        if (data.deleted !== undefined) {
-            (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Deleted ${data.deleted} cache entries`);
+        if (data.count !== undefined) {
+            (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Deleted ${data.count} cache entries`);
         }
     }
 }

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -20,33 +20,34 @@ describe("deleteCache", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: () => Promise.resolve({ deleted: 1 }),
+      json: () => Promise.resolve({ count: 1 }),
     } as Response);
   });
 
   const defaultParams = {
-    baseUrl: "https://api.blacksmith.sh/cache",
-    repoName: "test-repo",
+    baseUrl: "http://baseurl/",
     cacheToken: "test-token",
-    region: "eu-central",
   };
 
-  it("should send DELETE request for a specific cache key", async () => {
+  it("should send request to delete a specific cache key", async () => {
     await deleteCache({
       cacheKey: "npm-cache",
       ...defaultParams,
     });
 
     expect(mockedFetch).toHaveBeenCalledWith(
-      "https://api.blacksmith.sh/cache/caches/npm-cache",
+      "http://baseurl/twirp/github.actions.results.api.v1.CacheService/DeleteCacheEntry",
       {
-        method: "DELETE",
+        method: "POST",
         headers: {
+          "Content-Type": "application/json",
           Accept: "application/json; version=6.0-preview.1",
-          "X-GitHub-Repo-Name": "test-repo",
           Authorization: "Bearer test-token",
-          "X-Cache-Region": "eu-central",
         },
+        body: JSON.stringify({
+          key: "npm-cache",
+          prefix: false,
+        }),
       }
     );
     expect(mockedInfo).toHaveBeenCalledWith(
@@ -55,7 +56,7 @@ describe("deleteCache", () => {
     expect(mockedInfo).toHaveBeenCalledWith("Deleted 1 cache entries");
   });
 
-  it("should send DELETE request for a specific cache version", async () => {
+  it("should send request to delete a specific cache version", async () => {
     await deleteCache({
       cacheKey: "npm-cache",
       cacheVersion: "v1.0",
@@ -63,15 +64,19 @@ describe("deleteCache", () => {
     });
 
     expect(mockedFetch).toHaveBeenCalledWith(
-      "https://api.blacksmith.sh/cache/caches/npm-cache/v1.0",
+      "http://baseurl/twirp/github.actions.results.api.v1.CacheService/DeleteCacheEntry",
       {
-        method: "DELETE",
+        method: "POST",
         headers: {
+          "Content-Type": "application/json",
           Accept: "application/json; version=6.0-preview.1",
-          "X-GitHub-Repo-Name": "test-repo",
           Authorization: "Bearer test-token",
-          "X-Cache-Region": "eu-central",
         },
+        body: JSON.stringify({
+          key: "npm-cache",
+          version: "v1.0",
+          prefix: false,
+        }),
       }
     );
     expect(mockedInfo).toHaveBeenCalledWith(
@@ -80,12 +85,12 @@ describe("deleteCache", () => {
     expect(mockedInfo).toHaveBeenCalledWith("Deleted 1 cache entries");
   });
 
-  it("should send DELETE request with prefix parameter", async () => {
+  it("should send request with prefix parameter", async () => {
     mockedFetch.mockResolvedValue({
       ok: true,
       status: 200,
       statusText: "OK",
-      json: () => Promise.resolve({ deleted: 5 }),
+      json: () => Promise.resolve({ count: 5 }),
     } as Response);
 
     await deleteCache({
@@ -95,15 +100,18 @@ describe("deleteCache", () => {
     });
 
     expect(mockedFetch).toHaveBeenCalledWith(
-      "https://api.blacksmith.sh/cache/caches/npm-?prefix",
+      "http://baseurl/twirp/github.actions.results.api.v1.CacheService/DeleteCacheEntry",
       {
-        method: "DELETE",
+        method: "POST",
         headers: {
+          "Content-Type": "application/json",
           Accept: "application/json; version=6.0-preview.1",
-          "X-GitHub-Repo-Name": "test-repo",
           Authorization: "Bearer test-token",
-          "X-Cache-Region": "eu-central",
         },
+        body: JSON.stringify({
+          key: "npm-",
+          prefix: true,
+        }),
       }
     );
     expect(mockedInfo).toHaveBeenCalledWith(
@@ -112,12 +120,12 @@ describe("deleteCache", () => {
     expect(mockedInfo).toHaveBeenCalledWith("Deleted 5 cache entries");
   });
 
-  it("should send DELETE request with empty key and prefix parameter", async () => {
+  it("should send request with empty key and prefix parameter", async () => {
     mockedFetch.mockResolvedValue({
       ok: true,
       status: 200,
       statusText: "OK",
-      json: () => Promise.resolve({ deleted: 10 }),
+      json: () => Promise.resolve({ count: 10 }),
     } as Response);
 
     await deleteCache({
@@ -127,15 +135,18 @@ describe("deleteCache", () => {
     });
 
     expect(mockedFetch).toHaveBeenCalledWith(
-      "https://api.blacksmith.sh/cache/caches/?prefix",
+      "http://baseurl/twirp/github.actions.results.api.v1.CacheService/DeleteCacheEntry",
       {
-        method: "DELETE",
+        method: "POST",
         headers: {
+          "Content-Type": "application/json",
           Accept: "application/json; version=6.0-preview.1",
-          "X-GitHub-Repo-Name": "test-repo",
           Authorization: "Bearer test-token",
-          "X-Cache-Region": "eu-central",
         },
+        body: JSON.stringify({
+          key: "",
+          prefix: true,
+        }),
       }
     );
     expect(mockedInfo).toHaveBeenCalledWith(

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,23 +24,20 @@ interface DeleteCacheParams {
   cacheVersion?: string;
   prefix?: boolean;
   baseUrl?: string;
-  repoName?: string;
   cacheToken?: string;
-  region?: string;
 }
 
 export async function deleteCache({
   cacheKey,
   cacheVersion,
   prefix = false,
-  baseUrl = process.env.BLACKSMITH_CACHE_URL ||
-    (process.env.PETNAME?.includes("staging")
-      ? "https://stagingapi.blacksmith.sh/cache"
-      : "https://api.blacksmith.sh/cache"),
-  repoName = process.env["GITHUB_REPO_NAME"] ?? "",
+  baseUrl = process.env.ACTIONS_RESULTS_URL ?? "",
   cacheToken = process.env["BLACKSMITH_CACHE_TOKEN"],
-  region = process.env["BLACKSMITH_REGION"] ?? "eu-central",
 }: DeleteCacheParams): Promise<void> {
+  if (!baseUrl) {
+    throw new Error("ACTIONS_RESULTS_URL not set");
+  }
+
   if (!cacheKey && !prefix) {
     throw new Error("Cache key cannot be empty unless prefix is true");
   }
@@ -51,17 +48,25 @@ export async function deleteCache({
     throw new Error("Cannot specify version when using prefix");
   }
 
-  const resource = cacheVersion ? `${cacheKey}/${cacheVersion}` : cacheKey;
-  const url = `${baseUrl}/caches/${resource}`;
+  // The baseURL always has a trailing slash, but we still add it in case it is missing.
+  if (!baseUrl.endsWith("/")) {
+    baseUrl = `${baseUrl}/`;
+  }
+  const url = `${baseUrl}twirp/github.actions.results.api.v1.CacheService/DeleteCacheEntry`;
 
-  const response = await fetchWithRetry(prefix ? `${url}?prefix` : url, {
-    method: "DELETE",
+  const response = await fetchWithRetry(url, {
+    // Twirp endpoints all use POST.
+    method: "POST",
     headers: {
+      "Content-Type": "application/json",
       Accept: "application/json; version=6.0-preview.1",
-      "X-GitHub-Repo-Name": repoName,
       Authorization: `Bearer ${cacheToken}`,
-      "X-Cache-Region": region,
     },
+    body: JSON.stringify({
+      key: cacheKey,
+      version: cacheVersion,
+      prefix,
+    }),
   });
 
   if (!response.ok && response.status !== 404) {
@@ -81,8 +86,8 @@ export async function deleteCache({
         cacheVersion ? " version" : ""
       }: ${cacheKey}${cacheVersion ? `@${cacheVersion}` : ""}`
     );
-    if (data.deleted !== undefined) {
-      info(`Deleted ${data.deleted} cache entries`);
+    if (data.count !== undefined) {
+      info(`Deleted ${data.count} cache entries`);
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Migrated from REST API to Twirp RPC protocol

- Changed endpoint from REST DELETE to Twirp POST /DeleteCacheEntry
- Updated request format to use JSON body with 'key', 'version', 'prefix' fields
- Removed unused repoName and region parameters
- Updated tests to match new API structure
- Fixed response handling to use 'count' field instead of 'deleted'

This aligns with the github.actions.results.api.v1.CacheService proto definition