### PR TITLE
Update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
     default: "false"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.0.0",
         "@types/node-fetch": "^2.6.11",
         "@vercel/ncc": "^0.38.1",
         "eslint": "^9.15.0",
@@ -1422,13 +1422,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.7.tgz",
-      "integrity": "sha512-sZXXnpBFMKbao30dUAvzKbdwA2JM1fwUtVEq/kxKuPI5mMwZiRElCpTXb0Biq/LMEVpXDZL5G5V0RPnxKeyaYg==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -5073,9 +5073,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "^9.15.0",
     "typescript-eslint": "^8.15.0",
     "@vercel/ncc": "^0.38.1",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.6.11",
     "typescript": "^5.0.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This PR migrates the action runtime from `node20` to `node24`.

How it works: `action.yml` switches from `node20` to `node24`, `@types/node` is bumped from `^20.0.0` to `^24.0.0`, and `package-lock.json` is updated to match. No source code changes needed — the action uses stable Node APIs (`@actions/core`, `node-fetch`) that are unchanged across versions.

---
[View Codesmith session](https://staging.blacksmith.sh/useblacksmith/sessions/019d2a29-3e97-7079-bf70-9f20156c274e)